### PR TITLE
Update jdbc v2 0.9.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Tableau Connector Plugin SDK 
+      - name: Checkout Tableau Connector Plugin SDK
         uses: actions/checkout@v3
         with:
           repository: tableau/connector-plugin-sdk
-          ref: tableau-2023.2
+          ref: tableau-2024.2
 
       - name: Checkout ClickHouse Tableau JDBC connector
         uses: actions/checkout@v3
@@ -21,7 +21,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
+
+      - name: Run connector script tests
+        working-directory: clickhouse-tableau-jdbc
+        run: node tests/connection.test.js
 
       - name: Package the connector
         working-directory: connector-packager
@@ -32,31 +36,42 @@ jobs:
           python -m connector_packager.package ../clickhouse-tableau-jdbc/clickhouse_jdbc
           echo "TACO_FILE=$(find "$PWD" -name 'clickhouse*.taco' | head -n 1)" >> $GITHUB_ENV
 
+      - name: Upload the unsigned taco
+        uses: actions/upload-artifact@v4
+        with:
+          name: clickhouse_jdbc_unsigned.taco
+          path: ${{ env.TACO_FILE }}
+          if-no-files-found: error
+
       - name: Set up Java for signing
+        if: ${{ secrets.SM_HOST != '' }}
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
 
-      - name: Prepare for signing 
+      - name: Prepare for signing
+        if: ${{ secrets.SM_HOST != '' }}
         working-directory: clickhouse-tableau-jdbc/signing_utility
-        run: | 
+        run: |
           cp ./smpkcs11.so /tmp/smpkcs11.so
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/Certificate_pkcs12.p12 
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV" 
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV" 
-          echo "SM_CLIENT_CERT_FILE=/tmp/Certificate_pkcs12.p12" >> "$GITHUB_ENV" 
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV" 
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/Certificate_pkcs12.p12
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=/tmp/Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
           echo "DIGICERT_KEY_ALIAS=${{ secrets.DIGICERT_KEY_ALIAS }}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Sign binary
+        if: ${{ secrets.SM_HOST != '' }}
         working-directory: clickhouse-tableau-jdbc/signing_utility
-        run: | 
+        run: |
           jarsigner -keystore NONE  -storepass NONE -storetype PKCS11 -sigalg SHA256withRSA -providerClass sun.security.pkcs11.SunPKCS11 -providerArg pkcs11properties.cfg -signedjar  clickhouse_jdbc_signed.taco  $TACO_FILE $DIGICERT_KEY_ALIAS  -tsa  http://timestamp.digicert.com
         shell: bash
 
-      - name: Upload the taco
+      - name: Upload the signed taco
+        if: ${{ secrets.SM_HOST != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: clickhouse_jdbc_signed.taco

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ This is an extension for Tableau Desktop / Tableau Server that simplifies the pr
 ## Before you install
 
 Requirements
-- Tableau **2020.4+**
-- ClickHouse **20.7+**
+- Tableau **2024.2+** — the JDBC driver requires Java 17+, which is bundled with Tableau starting from 2024.2
+- ClickHouse **24.x+** (**25.6+ recommended** — the connector uses `toTimeWithFixedDate()` for the MAKETIME function, available unconditionally since 25.6)
+- ClickHouse JDBC driver **0.9.8+** (JDBC V2). The connector builds connection parameters for the V2 driver only; V1-era options (`custom_http_params`, `typeMappings`, `sslmode`) are no longer used
+
+> [!IMPORTANT]
+> The account used for the connection must **not** have `readonly=1`. The V2 driver sends server settings (e.g. `async_insert=0`, `wait_end_of_query=0`) with every request, which a `readonly=1` profile rejects. Use `readonly=2` (settings changes allowed, writes denied) or `readonly=0`. Check with `SELECT getSetting('readonly')`.
 
 ## Installation (Tableau Desktop)
-1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.X required), and place the `clickhouse-jdbc-0.9.X-all-dependencies.jar` to:
+1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.8 or newer), and place the `clickhouse-jdbc-0.9.8-all-dependencies.jar` to:
     - macOS: `~/Library/Tableau/Drivers`
     - Windows: `C:\Program Files\Tableau\Drivers`
     - You need to create the folder if it doesn't already exist
@@ -27,7 +31,7 @@ Requirements
 4. In Tableau Desktop: **Connect** ➔ **To a Server** ➔ **ClickHouse JDBC by ClickHouse, Inc.**
 
 ## Installation (Tableau Prep Builder)
-1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.X required), and place the `clickhouse-jdbc-0.9.X-all-dependencies.jar` to:
+1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.8 or newer), and place the `clickhouse-jdbc-0.9.8-all-dependencies.jar` to:
     - macOS: `~/Library/Tableau/Drivers`
     - Windows: `C:\Program Files\Tableau\Drivers`
     - You need to create the folder if it doesn't already exist
@@ -38,7 +42,7 @@ Requirements
 4. In Tableau Prep Builder: **Connections** ➔ **+** ➔ **To a Server** ➔ **ClickHouse JDBC by ClickHouse, Inc.**
 
 ## Installation (Tableau Server)
-1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.X required), and place the `clickhouse-jdbc-0.9.X-all-dependencies.jar` to:
+1. Download the [Clickhouse JDBC Driver](https://github.com/ClickHouse/clickhouse-java/releases) (version 0.9.8 or newer), and place the `clickhouse-jdbc-0.9.8-all-dependencies.jar` to:
     - Linux: `/opt/tableau/tableau_driver/jdbc`
     - Windows: `C:\Program Files\Tableau\Drivers`
     - You need to create the directory if it doesn't already exist
@@ -63,6 +67,19 @@ Requirements
     tsm restart
     ```
     - Note that whenever you add, remove, or update a connector, you need to restart the server to see the changes.
+
+## Installing an unsigned .taco (internal builds)
+Internally distributed builds of this connector are not signed with a DigiCert certificate, so Tableau's signature verification must be disabled. This also works around the OCSP verification bug in Tableau 2025.1+ that rejects previously valid signatures ([issue #96](https://github.com/ClickHouse/clickhouse-tableau-connector-jdbc/issues/96)).
+- **Tableau Desktop** — start with the flag:
+    ```
+    tableau.exe -DDisableVerifyConnectorPluginSignature=true
+    ```
+    (macOS: pass the same `-D` flag to the Tableau binary inside the app bundle)
+- **Tableau Server**:
+    ```
+    tsm configuration set -k native_api.disable_verify_connector_plugin_signature -v true
+    tsm pending-changes apply
+    ```
 ## Connection tips
 ### Initial SQL tab
 If the *Set Session ID* checkbox is activated on the Advanced tab (by default), feel free to set session level [settings](https://clickhouse.com/docs/en/operations/settings/settings/) using
@@ -73,30 +90,18 @@ SET my_setting=value;
 
 
 In 99% of cases you don't need the Advanced tab, for the remaining 1% you can use the following settings:
-- **Custom Connection Parameters (Unavailable for Tableau Exchange distribution)**.  By default, `socket_timeout` is already specified, this parameter may need to be changed if some extracts are updated for a very long time. The value of this parameter is specified in milliseconds. The rest of the parameters can be found [here](https://github.com/ClickHouse/clickhouse-jdbc/blob/master/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java), add them in this field separated by commas
-- **JDBC Driver custom_http_params**. This field allows you to drop some parameters into the ClickHouse connection string by passing values to the [`custom_http_params` parameter of the driver](https://github.com/ClickHouse/clickhouse-jdbc#configuration). For example, this is how `session_id` is specified when the *Set Session ID* checkbox is activated
-- **JDBC Driver typeMappings**. This field allows you to [pass a list of ClickHouse data type mappings to Java data types used by the JDBC driver](https://github.com/ClickHouse/clickhouse-jdbc#configuration). The connector automatically displays large Integers as strings thanks to this parameter, you can change this by passing your mapping set *(I do not know why)* using
-    ```
-    UInt256=java.lang.Double,Int256=java.lang.Double
-    ```
-    Read more about mapping in the corresponding section
-
-- **JDBC Driver URL Parameters**. You can pass the remaining [driver parameters](https://github.com/ClickHouse/clickhouse-jdbc#configuration), for example `jdbcCompliance`, in this field. Be careful, the parameter values must be passed in the URL Encoded format, and in the case of passing `custom_http_params` or `typeMappings` in this field and in the previous fields of the Advanced tab, the values of the preceding two fields on the Advanced tab have a higher priority
+- **JDBC driver properties**. Driver-level connection properties passed as `key=value` pairs separated by commas, see the [driver configuration reference](https://clickhouse.com/docs/integrations/language-clients/java/jdbc). By default, `socket_timeout=300000` (milliseconds) is specified; increase it if some extracts take a very long time to refresh. The connector also sets `ignore_unknown_config_key=true` by default, so unknown property names produce a WARN in the driver log instead of a connection failure; pass `ignore_unknown_config_key=false` in this field to make typos fail fast.
+- **ClickHouse server settings**. `key=value` pairs separated by commas, sent as [ClickHouse server settings](https://clickhouse.com/docs/operations/settings/settings) with every request of the connection (each key is passed to the driver as `clickhouse_setting_<key>`). For example, `max_result_rows=1000000`. This field replaces the old *JDBC Driver custom_http_params* field with the same `key=value` semantics — saved data sources keep working.
+- **JDBC Driver URL Parameters**. Raw driver URL parameters, applied **last** — they override everything set by the connector or the fields above. For example, passing `clickhouse_setting_session_id=my-session` here overrides the session id generated by the *Set Session ID* checkbox.
 - **Set Session ID** checkbox. It is needed to set session-level settings in Initial SQL tab, generates a `session_id` with a timestamp and a pseudo-random number in the format "tableau-jdbc-connector-*{timestamp}*-*{number}*"
-### Limited support for UInt64, Int128, (U)Int256 data types
-By default, the driver displays fields of types *UInt64, Int128, (U)Int256* as strings, **but it displays, not converts**. This means that when you try to write the next calculated field, you will get an error
-```
-LEFT([myUInt256], 2) // Error!
-```
-In order to work with large Integer fields as with strings, it is necessary to explicitly wrap the field in the STR() function
-```
-LEFT(STR([myUInt256]), 2) // Works well!
-```
-However, such fields are most often used to find the number of unique values *(IDs as Watch ID, Visit ID in Yandex.Metrika)* or as a *Dimension* to specify the detail of the visualization, it works well.
-```
-COUNTD([myUInt256]) // Works well too!
-```
-When using the data preview (View data) of a table with UInt64 fields, an error does not appear now.
+
+Priority order (lowest to highest): connector defaults (`join_use_nulls=1`) ➔ *Set Session ID* checkbox ➔ *ClickHouse server settings* ➔ *JDBC Driver URL Parameters*.
+### UInt64, Int128, (U)Int256 data types (migration note)
+Since JDBC driver 0.9.x (V2), large integer fields are reported as **NUMERIC** and read by Tableau as decimal numbers, not strings as in older connector versions. Note:
+- Values above 2^53 lose precision when used in float-based calculations in Tableau.
+- `COUNTD([myUInt64])` and using such fields as a *Dimension* keep working fine.
+- If you need exact string representation (e.g. IDs like Watch ID / Visit ID), cast on the ClickHouse side: `toString(myUInt64)` in a custom SQL query or a view.
+- Workbooks created with connector v0.x that relied on the old `typeMappings` behavior will see these fields change type from String to Number. The driver's `typeMappings` option was removed in JDBC V2; a replacement (`jdbc_type_map`) is expected in driver 0.10.0.
 ## Analysis tips
 ### MEDIAN() and PERCENTILE() functions
 - In Live mode the MEDIAN() and PERCENTILE() functions (since connector v0.1.3 release) use the [ClickHouse quantile()() function](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/quantile/), which significantly speeds up the calculation, but uses sampling. If you want to get accurate calculation results, then use functions `MEDIAN_EXACT()` and `PERCENTILE_EXACT()` (based on [quantileExact()()](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/quantileexact/)).
@@ -149,8 +154,10 @@ ClickHouse has a huge number of functions that can be used for data analysis —
 - **`TRUNC([my_float])`** — It is the same as the `FLOOR([my_float])` function. Equivalent of [`trunc()`](https://clickhouse.com/docs/en/sql-reference/functions/rounding-functions/#truncx-n-truncatex-n).
 - **`UNHEX([my_string])`** *(added in v0.2.1)* — Performs the opposite operation of `HEX()`. Equivalent of [`unhex()`](https://clickhouse.com/docs/en/sql-reference/functions/encoding-functions/#unhexstr).
 
-## Future plans
-- Publishing the connector at [exchange.tableau.com](https://exchange.tableau.com/connectors)
+## Troubleshooting
+- **A typo in *JDBC driver properties* silently does nothing.** With the default `ignore_unknown_config_key=true`, the driver logs `Unknown and unmapped config properties` as WARN in `jprotocolserver.log` (in *My Tableau Repository/Logs*) instead of failing. Pass `ignore_unknown_config_key=false` in the *JDBC driver properties* field to surface such errors at connection time.
+- **`SESSION_IS_LOCKED` errors.** A ClickHouse session allows only one running query at a time. The connector intentionally does not advertise query cancellation support (`KILL QUERY` from the same session would lock itself out), but if you see this error with parallel queries, untick the *Set Session ID* checkbox (this disables `SET` statements in Initial SQL).
+- **Connection fails for a `readonly=1` account.** Not fixable on the connector side — the JDBC V2 driver sends server settings with every request. Ask your DBA for a `readonly=2` profile.
 
 ## Tests
 The connector is being tested with the [TDVT framework](https://tableau.github.io/connector-plugin-sdk/docs/tdvt) and currently maintains a 97% coverage ratio.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Internally distributed builds of this connector are not signed with a DigiCert c
 If the *Set Session ID* checkbox is activated on the Advanced tab (by default), feel free to set session level [settings](https://clickhouse.com/docs/en/operations/settings/settings/) using
 ```
 SET my_setting=value;
-``` 
+```
+> **Migration note: `USE my_database;` in Initial SQL no longer works.** The JDBC V2 driver sends an explicit database with every request, which overrides the session's current database set by `USE`. Instead, the database you pick in the Tableau UI is now applied to the connection automatically (so unqualified tables in Custom SQL resolve there), or set it explicitly with `database=my_database` in *JDBC driver properties* on the Advanced tab.
+### Default database for Custom SQL
+The **Database** you select on the data source page becomes the default database of the connection. Unqualified table names in *New Custom SQL* resolve against it. To use a different database, either qualify tables (`my_db.my_table`) or pass `database=my_db` in *JDBC driver properties* (it overrides the UI selection).
 ### Advanced tab
 
 
@@ -158,6 +161,7 @@ ClickHouse has a huge number of functions that can be used for data analysis —
 - **A typo in *JDBC driver properties* silently does nothing.** With the default `ignore_unknown_config_key=true`, the driver logs `Unknown and unmapped config properties` as WARN in `jprotocolserver.log` (in *My Tableau Repository/Logs*) instead of failing. Pass `ignore_unknown_config_key=false` in the *JDBC driver properties* field to surface such errors at connection time.
 - **`SESSION_IS_LOCKED` errors.** A ClickHouse session allows only one running query at a time. The connector intentionally does not advertise query cancellation support (`KILL QUERY` from the same session would lock itself out), but if you see this error with parallel queries, untick the *Set Session ID* checkbox (this disables `SET` statements in Initial SQL).
 - **Connection fails for a `readonly=1` account.** Not fixable on the connector side — the JDBC V2 driver sends server settings with every request. Ask your DBA for a `readonly=2` profile.
+- **`Unknown table expression identifier` in Custom SQL.** The table is not in the connection's default database. Select the right **Database** on the data source page (it is applied to the connection), qualify the table name (`my_db.my_table`), or pass `database=my_db` in *JDBC driver properties*. Note that `USE my_db;` in Initial SQL does **not** work with the V2 driver.
 
 ## Tests
 The connector is being tested with the [TDVT framework](https://tableau.github.io/connector-plugin-sdk/docs/tdvt) and currently maintains a 97% coverage ratio.

--- a/clickhouse_jdbc/connection-fields.xml
+++ b/clickhouse_jdbc/connection-fields.xml
@@ -13,17 +13,14 @@
       <true-value value='require'/>
     </boolean-options>
   </field>
-  <field name='v-custom-connection-params' label='Custom Connection Parameters (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true' default-value='socket_timeout=300000'>
-    <validation-rule reg-exp='^((([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+,)*([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+))?)$'/>
+  <field name='v-custom-connection-params' label='JDBC driver properties (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true' default-value='socket_timeout=300000'>
+    <validation-rule reg-exp='^((([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+,)*([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+))?)$'/>
   </field>
-  <field name='v-custom-http-params' label='JDBC Driver custom_http_params (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true'>
-    <validation-rule reg-exp='^((([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+,)*([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+))?)$'/>
-  </field>
-  <field name='v-custom-type-mappings' label='JDBC Driver typeMappings (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true'>
-    <validation-rule reg-exp='^((([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+,)*([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+))?)$'/>
+  <field name='v-custom-http-params' label='ClickHouse server settings (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true'>
+    <validation-rule reg-exp='^((([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+,)*([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+))?)$'/>
   </field>
   <field name='v-custom-url-params' label='JDBC Driver URL Parameters (key1=value1,key2=value2)' category='advanced' value-type='string' optional='true'>
-    <validation-rule reg-exp='^((([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+,)*([a-zA-Z0-9\_]+=[a-zA-Z0-9\_\-\.\/\@\*\%]+))?)$'/>
+    <validation-rule reg-exp='^((([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+,)*([a-zA-Z0-9\_\.\-]+=[a-zA-Z0-9\_\-\.\/\@\*\%\:\+]+))?)$'/>
   </field>
   <field name='v-set-session-id' label='Set Session ID (allow for setting Session Parameters in the Initial SQL)' value-type='boolean' category='advanced' default-value='true'>
     <boolean-options>

--- a/clickhouse_jdbc/connectionBuilder.js
+++ b/clickhouse_jdbc/connectionBuilder.js
@@ -1,75 +1,64 @@
 (function dsbuilder(attr) {
-    // setting custom HTTP parameterss
-    var customHttpParams = {};
+    // Splits "k1=v1,k2=v2" on the FIRST '=' of each item, so values may
+    // contain '='. Pairs with an empty key or value are skipped: jdbc-v2
+    // parseUrl() throws SQLException on empty URL parameter keys/values.
+    function parseKeyValueList(str) {
+        var pairs = [];
+        if (!str || str.length === 0) {
+            return pairs;
+        }
+        var items = str.split(',');
+        for (var i = 0; i < items.length; i++) {
+            var eq = items[i].indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            var key = items[i].substring(0, eq).replace(/^\s+|\s+$/g, '');
+            var value = items[i].substring(eq + 1).replace(/^\s+|\s+$/g, '');
+            if (key.length === 0 || value.length === 0) {
+                continue;
+            }
+            pairs.push([key, value]);
+        }
+        return pairs;
+    }
+
+    // Single params object: later assignments override earlier ones
+    var params = {};
 
     // fix IN/OUT Top-N Sets
-    customHttpParams['join_use_nulls'] = 1;
+    params['clickhouse_setting_join_use_nulls'] = '1';
 
-    // parsing custom_http_params
-    if(attr['v-custom-http-params'] && attr['v-custom-http-params'].length > 0){
-        var customParams = attr['v-custom-http-params'].split(',');
-        for(var i = 0; i < customParams.length; i++){
-            var param = customParams[i].split('=');
-            customHttpParams[param[0]] = param[1];
-        }
-    }
-    
-    // setting session_id
-    if(attr['v-set-session-id'] == "true"){
-        customHttpParams['session_id'] = "tableau-jdbc-connector-" + Date.now() + "-" + Math.floor(Math.random() * (Math.floor(10000000) - Math.ceil(1) + 1)) + Math.ceil(1);
+    // session_id is sent with every HTTP request by the driver, which gives
+    // a real server session, so Initial SQL "SET x=y" affects the connection
+    if (attr['v-set-session-id'] == 'true') {
+        params['clickhouse_setting_session_id'] = 'tableau-jdbc-connector-' + Date.now() + '-'
+            + (Math.floor(Math.random() * (Math.floor(10000000) - Math.ceil(1) + 1)) + Math.ceil(1));
     }
 
-    var customHttpParamsArr = [];
-    for (var key in customHttpParams){
-        customHttpParamsArr.push(key + "=" + customHttpParams[key]);
+    // ClickHouse server settings: each key becomes clickhouse_setting_<key>,
+    // keeping the semantics of the old V1 custom_http_params field
+    var serverSettings = parseKeyValueList(attr['v-custom-http-params']);
+    for (var i = 0; i < serverSettings.length; i++) {
+        params['clickhouse_setting_' + serverSettings[i][0]] = serverSettings[i][1];
     }
 
-    // preparing customUrlParams
-    var customUrlParams = {};
-
-    if(attr['v-custom-url-params'] && attr['v-custom-url-params'].length > 0){
-        var customParams = attr['v-custom-url-params'].split(',');
-        for(var i = 0; i < customParams.length; i++){
-            var param = customParams[i].split('=');
-            customUrlParams[param[0]] = param[1];
-        }
+    // raw JDBC URL parameters go last, so an explicit
+    // clickhouse_setting_session_id here overrides the checkbox above
+    var urlParams = parseKeyValueList(attr['v-custom-url-params']);
+    for (var j = 0; j < urlParams.length; j++) {
+        params[urlParams[j][0]] = urlParams[j][1];
     }
 
-    // default type mappings
-    typeMappings = {'UInt64': 'java.lang.String',
-                    'UInt128': 'java.lang.String',
-                    'Int128': 'java.lang.String',
-                    'UInt256': 'java.lang.String',
-                    'Int256': 'java.lang.String'};
-
-    // setting custom type mappings
-    if(attr['v-custom-type-mappings'] && attr['v-custom-type-mappings'].length > 0){
-        var customTypeMappings = attr['v-custom-type-mappings'].split(',');
-        for(var i in customTypeMappings){
-            var customTypeMapping = customTypeMappings[i].split('=');
-            typeMappings[customTypeMapping[0]] = customTypeMapping[1];
-        }
+    var paramsArr = [];
+    for (var key in params) {
+        paramsArr.push(key + '=' + encodeURIComponent(params[key]));
     }
 
-    var typeMappingsArr = [];
-    for (var key in typeMappings){
-        typeMappingsArr.push(key + "=" + typeMappings[key]);
+    var hostPort = attr['server'];
+    if (attr['port'] && attr['port'].length > 0) {
+        hostPort += ':' + attr['port'];
     }
 
-    // updating some URL params
-    customUrlParams['custom_http_params'] = customHttpParamsArr.join(',');
-    customUrlParams['typeMappings'] = typeMappingsArr.join(',');
-
-    // building encoded URL params string
-    var customUrlParamsArr = [];
-    for (var key in customUrlParams){
-        customUrlParamsArr.push(key + "=" + encodeURIComponent(customUrlParams[key]));
-    }
-
-    var customUrlParamsString = customUrlParamsArr.join('&');
-
-    // building full URL string
-    var urlBuilder = "jdbc:clickhouse://" + attr['server'] + ":" + attr['port']
-        + "/?" + customUrlParamsString;
-    return [urlBuilder];
+    return ['jdbc:clickhouse://' + hostPort + '/?' + paramsArr.join('&')];
 })

--- a/clickhouse_jdbc/connectionProperties.js
+++ b/clickhouse_jdbc/connectionProperties.js
@@ -1,21 +1,44 @@
 (function propertiesbuilder(attr) {
-    var props = {};
-
-    // setting custom Connection Parameters
-    if(attr["v-custom-connection-params"] && attr["v-custom-connection-params"].length > 0){
-        var customParams = attr["v-custom-connection-params"].split(',');
-        for(var i = 0; i < customParams.length; i++){
-            var param = customParams[i].split('=');
-            props[param[0]] = param[1];
+    // Same parsing rules as connectionBuilder.js: split on the first '=',
+    // skip pairs with an empty key or value
+    function parseKeyValueList(str) {
+        var pairs = [];
+        if (!str || str.length === 0) {
+            return pairs;
         }
+        var items = str.split(',');
+        for (var i = 0; i < items.length; i++) {
+            var eq = items[i].indexOf('=');
+            if (eq < 0) {
+                continue;
+            }
+            var key = items[i].substring(0, eq).replace(/^\s+|\s+$/g, '');
+            var value = items[i].substring(eq + 1).replace(/^\s+|\s+$/g, '');
+            if (key.length === 0 || value.length === 0) {
+                continue;
+            }
+            pairs.push([key, value]);
+        }
+        return pairs;
     }
 
-    props["user"] = attr["username"];
-    props["password"] = attr["password"];
-   
-    if (attr["sslmode"] == "require") {
-        props["ssl"] = "true";
-        props["sslmode"] = "STRICT";
+    var props = {};
+
+    // jdbc-v2 (0.9.7+) rejects unknown config keys with
+    // ClientMisconfigurationException; with this flag the driver only logs
+    // a WARN. Users can override it back to 'false' in the field below.
+    props['ignore_unknown_config_key'] = 'true';
+
+    var customProps = parseKeyValueList(attr['v-custom-connection-params']);
+    for (var i = 0; i < customProps.length; i++) {
+        props[customProps[i][0]] = customProps[i][1];
+    }
+
+    props['user'] = attr['username'] ? attr['username'] : 'default';
+    props['password'] = attr['password'] ? attr['password'] : '';
+
+    if (attr['sslmode'] == 'require') {
+        props['ssl'] = 'true';
     }
 
     return props;

--- a/clickhouse_jdbc/connectionProperties.js
+++ b/clickhouse_jdbc/connectionProperties.js
@@ -29,6 +29,15 @@
     // a WARN. Users can override it back to 'false' in the field below.
     props['ignore_unknown_config_key'] = 'true';
 
+    // The database picked in the Tableau UI becomes the connection default
+    // database, so unqualified tables in Custom SQL resolve there. jdbc-v2
+    // sends an explicit database with every request, which overrides any
+    // "USE db" from Initial SQL — mapping the schema here replaces that
+    // old V1 pattern. An explicit database=... below still wins.
+    if (attr['schema'] && attr['schema'].length > 0) {
+        props['database'] = attr['schema'];
+    }
+
     var customProps = parseKeyValueList(attr['v-custom-connection-params']);
     for (var i = 0; i < customProps.length; i++) {
         props[customProps[i][0]] = customProps[i][1];

--- a/clickhouse_jdbc/connectionResolver.tdr
+++ b/clickhouse_jdbc/connectionResolver.tdr
@@ -14,6 +14,7 @@
           <attr>username</attr>
           <attr>password</attr>
           <attr>sslmode</attr>
+          <attr>schema</attr>
           <attr>v-custom-connection-params</attr>
           <attr>v-custom-http-params</attr>
           <attr>v-custom-url-params</attr>

--- a/clickhouse_jdbc/connectionResolver.tdr
+++ b/clickhouse_jdbc/connectionResolver.tdr
@@ -16,7 +16,6 @@
           <attr>sslmode</attr>
           <attr>v-custom-connection-params</attr>
           <attr>v-custom-http-params</attr>
-          <attr>v-custom-type-mappings</attr>
           <attr>v-custom-url-params</attr>
           <attr>v-set-session-id</attr>
         </attribute-list>

--- a/clickhouse_jdbc/dialect.tdd
+++ b/clickhouse_jdbc/dialect.tdd
@@ -578,7 +578,7 @@
       <argument type='datetime' />
     </function>
     <function group='cast' name='MAKETIME' return-type='datetime'>
-      <formula>toTime(addSeconds(addMinutes(addHours(DATE '1970-01-02', CAST(%1 AS Nullable(INTEGER))), CAST(%2 AS Nullable(INTEGER))), CAST(%3 AS Nullable(INTEGER))))</formula>
+      <formula>toTimeWithFixedDate(addSeconds(addMinutes(addHours(DATE '1970-01-02', CAST(%1 AS Nullable(INTEGER))), CAST(%2 AS Nullable(INTEGER))), CAST(%3 AS Nullable(INTEGER))))</formula>
       <argument type='int' />
       <argument type='int' />
       <argument type='int' />

--- a/clickhouse_jdbc/manifest.xml
+++ b/clickhouse_jdbc/manifest.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8' ?>
-<connector-plugin class='clickhouse_jdbc' superclass='jdbc' plugin-version='0.3.1' name='ClickHouse JDBC' version='18.1' min-version-tableau='2020.4'>
+<connector-plugin class='clickhouse_jdbc' superclass='jdbc' plugin-version='1.0.0' name='ClickHouse JDBC' version='18.1' min-version-tableau='2024.2'>
   <vendor-information>
     <company name='ClickHouse, Inc.'/>
     <support-link url='https://github.com/ClickHouse/clickhouse-tableau-connector-jdbc/issues'/>
-    <driver-download-link url='https://github.com/ClickHouse/clickhouse-jdbc/releases'/>
+    <driver-download-link url='https://github.com/ClickHouse/clickhouse-java/releases'/>
   </vendor-information>
   <connection-customization class='clickhouse_jdbc' enabled='true' version='10.0'>
     <vendor name='vendor'/>

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,153 @@
+// Tests for the connector's Tableau JS scripts. Run with: node tests/connection.test.js
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+
+function loadScript(name) {
+    var src = fs.readFileSync(path.join(__dirname, '..', 'clickhouse_jdbc', name), 'utf8');
+    // each script is a single parenthesized function expression
+    return eval(src);
+}
+
+var dsbuilder = loadScript('connectionBuilder.js');
+var propertiesbuilder = loadScript('connectionProperties.js');
+
+function buildUrl(attr) {
+    return dsbuilder(attr)[0];
+}
+
+function urlParams(url) {
+    var query = url.split('/?')[1];
+    var params = {};
+    if (!query || query.length === 0) {
+        return params;
+    }
+    var parts = query.split('&');
+    for (var i = 0; i < parts.length; i++) {
+        var eq = parts[i].indexOf('=');
+        params[parts[i].substring(0, eq)] = decodeURIComponent(parts[i].substring(eq + 1));
+    }
+    return params;
+}
+
+var failures = 0;
+function test(name, fn) {
+    try {
+        fn();
+        console.log('ok   ' + name);
+    } catch (e) {
+        failures++;
+        console.error('FAIL ' + name + '\n     ' + e.message);
+    }
+}
+
+// --- connectionBuilder.js ---
+
+test('default URL has host:port, join_use_nulls and a generated session_id', function () {
+    var url = buildUrl({ server: 'localhost', port: '8123', 'v-set-session-id': 'true' });
+    assert.strictEqual(url.indexOf('jdbc:clickhouse://localhost:8123/?'), 0);
+    var params = urlParams(url);
+    assert.strictEqual(params['clickhouse_setting_join_use_nulls'], '1');
+    assert.ok(/^tableau-jdbc-connector-\d+-\d+$/.test(params['clickhouse_setting_session_id']));
+});
+
+test('session checkbox off produces no session_id', function () {
+    var url = buildUrl({ server: 'localhost', port: '8123', 'v-set-session-id': 'false' });
+    assert.strictEqual(url.indexOf('session_id'), -1);
+});
+
+test('empty port leaves no colon in the URL', function () {
+    var url = buildUrl({ server: 'myhost', port: '', 'v-set-session-id': 'false' });
+    assert.strictEqual(url.indexOf('jdbc:clickhouse://myhost/?'), 0);
+});
+
+test('server settings field maps keys to clickhouse_setting_ prefix', function () {
+    var url = buildUrl({
+        server: 'h', port: '8123', 'v-set-session-id': 'false',
+        'v-custom-http-params': 'max_result_rows=1000,readonly=2'
+    });
+    var params = urlParams(url);
+    assert.strictEqual(params['clickhouse_setting_max_result_rows'], '1000');
+    assert.strictEqual(params['clickhouse_setting_readonly'], '2');
+});
+
+test('explicit session_id in URL params overrides the checkbox', function () {
+    var url = buildUrl({
+        server: 'h', port: '8123', 'v-set-session-id': 'true',
+        'v-custom-url-params': 'clickhouse_setting_session_id=my-fixed-session'
+    });
+    var params = urlParams(url);
+    assert.strictEqual(params['clickhouse_setting_session_id'], 'my-fixed-session');
+    // no duplicate session_id parameter in the URL
+    assert.strictEqual(url.split('clickhouse_setting_session_id=').length, 2);
+});
+
+test('values containing = are not truncated and are URL-encoded', function () {
+    var url = buildUrl({
+        server: 'h', port: '8123', 'v-set-session-id': 'false',
+        'v-custom-url-params': 'custom_settings=a=1'
+    });
+    assert.ok(url.indexOf('custom_settings=a%3D1') >= 0);
+});
+
+test('malformed pairs (empty key, empty value, bare items) are skipped', function () {
+    var url = buildUrl({
+        server: 'h', port: '8123', 'v-set-session-id': 'false',
+        'v-custom-http-params': 'a=,=b,,junk',
+        'v-custom-url-params': ' = , c '
+    });
+    var params = urlParams(url);
+    var keys = [];
+    for (var k in params) {
+        keys.push(k);
+    }
+    assert.deepStrictEqual(keys, ['clickhouse_setting_join_use_nulls']);
+});
+
+test('keys and values are trimmed', function () {
+    var url = buildUrl({
+        server: 'h', port: '8123', 'v-set-session-id': 'false',
+        'v-custom-http-params': ' max_result_rows = 1000 '
+    });
+    assert.strictEqual(urlParams(url)['clickhouse_setting_max_result_rows'], '1000');
+});
+
+// --- connectionProperties.js ---
+
+test('defaults: ignore_unknown_config_key=true, user fallback, empty password', function () {
+    var props = propertiesbuilder({});
+    assert.strictEqual(props['ignore_unknown_config_key'], 'true');
+    assert.strictEqual(props['user'], 'default');
+    assert.strictEqual(props['password'], '');
+});
+
+test('username and password pass through', function () {
+    var props = propertiesbuilder({ username: 'bob', password: 'secret' });
+    assert.strictEqual(props['user'], 'bob');
+    assert.strictEqual(props['password'], 'secret');
+});
+
+test('sslmode=require sets only ssl=true, never sslmode', function () {
+    var props = propertiesbuilder({ sslmode: 'require' });
+    assert.strictEqual(props['ssl'], 'true');
+    assert.strictEqual(props['sslmode'], undefined);
+});
+
+test('sslmode empty sets no ssl property', function () {
+    var props = propertiesbuilder({ sslmode: '' });
+    assert.strictEqual(props['ssl'], undefined);
+});
+
+test('custom connection params are applied and may override defaults', function () {
+    var props = propertiesbuilder({
+        'v-custom-connection-params': 'socket_timeout=300000,ignore_unknown_config_key=false'
+    });
+    assert.strictEqual(props['socket_timeout'], '300000');
+    assert.strictEqual(props['ignore_unknown_config_key'], 'false');
+});
+
+if (failures > 0) {
+    console.error('\n' + failures + ' test(s) failed');
+    process.exit(1);
+}
+console.log('\nAll tests passed');

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -146,6 +146,24 @@ test('custom connection params are applied and may override defaults', function 
     assert.strictEqual(props['ignore_unknown_config_key'], 'false');
 });
 
+test('schema picked in the UI becomes the connection database', function () {
+    var props = propertiesbuilder({ schema: 'hily_analytics' });
+    assert.strictEqual(props['database'], 'hily_analytics');
+});
+
+test('empty or missing schema sets no database property', function () {
+    assert.strictEqual(propertiesbuilder({ schema: '' })['database'], undefined);
+    assert.strictEqual(propertiesbuilder({})['database'], undefined);
+});
+
+test('explicit database= in custom params overrides the UI schema', function () {
+    var props = propertiesbuilder({
+        schema: 'hily_analytics',
+        'v-custom-connection-params': 'database=other_db'
+    });
+    assert.strictEqual(props['database'], 'other_db');
+});
+
 if (failures > 0) {
     console.error('\n' + failures + ' test(s) failed');
     process.exit(1);


### PR DESCRIPTION
 ## Motivation

  The connector was written for the legacy V1 JDBC driver and no longer works correctly with `clickhouse-jdbc` 0.8.x/0.9.x, where the **V2 driver is the default**. The V1-era options the connector relies on are removed or deprecated in V2:
  - `custom_http_params` / `typeMappings` URL parameters
  - `sslmode=STRICT` property
  - since driver `0.9.7`, **unknown config keys throw** `ClientMisconfigurationException`, so the old extra params now break the connection outright

This PR migrates the connector to the `V2` driver (verified against `clickhouse-jdbc` 0.9.8) and ClickHouse server 26.2, while keeping saved data sources working where possible.

  ## Changes

  ### Connection scripts
  - **`connectionBuilder.js`** — rebuilt for V2:
    - `join_use_nulls=1` is now passed as a server setting (`clickhouse_setting_join_use_nulls`)
    - the *Set Session ID* checkbox emits `clickhouse_setting_session_id=…`, which the driver attaches to every HTTP request, giving a real ClickHouse session so `SET …` in Initial SQL still applies to the connection
    - the *server settings* field maps each `key=value` to `clickhouse_setting_<key>` (same effective semantics as the old `custom_http_params`, so existing saved data sources keep working)
    - raw URL parameters are applied last and override everything
    - the `key=value` parser now splits on the first `=`, trims, and skips empty keys/values (V2 `parseUrl()` throws on empty URL parameter keys/values)
  - **`connectionProperties.js`**:
    - sets `ignore_unknown_config_key=true` by default (overridable in the field), so unexpected properties log a WARN instead of failing the connection
    - `sslmode=require` now sets `ssl=true` only (the V2 driver has no `sslmode`)
    - maps the **database selected in the UI** to the connection `database` property, so unqualified tables in Custom SQL resolve against it (`USE db` in Initial SQL no longer works in V2 — the driver sends an explicit database header with every request)
    - guards against undefined username/password

  ### Metadata & dialect
  - **`connection-fields.xml` / `connectionResolver.tdr`** — removed the `typeMappings` field (no V2 equivalent until the driver ships `jdbc_type_map`; `UInt64`/`UInt128`/`(U)Int256` are now reported as `NUMERIC`), renamed labels to match V2 semantics, widened validation regexes (dots/dashes in keys, `:`/`+` in values), and added `schema` to the attribute list.
  - **`manifest.xml`** — `plugin-version` 1.0.0, `min-version-tableau` 2024.2 (the V2 driver requires Java 17, which Tableau 2024.2+ bundles), `driver-download-link` updated to the `clickhouse-java` releases page.
  - **`dialect.tdd`** — `MAKETIME` now uses `toTimeWithFixedDate()` instead of `toTime()`. The two are equivalent today, but `toTime()`'s behavior changes when `use_legacy_to_time=false`; `toTimeWithFixedDate()` (available since 25.6) is stable.

  ### CI & docs
  - **`.github/workflows/release.yml`** — SDK pinned to `tableau-2024.2`, Python 3.11, Java 17; runs the new JS tests; always uploads the (unsigned) taco artifact; signing steps are now conditional on the signing secrets being present so forks can build without them.
  - **`README.md`** — updated requirements (driver 0.9.x all-dependencies jar, Tableau 2024.2+), migration notes (`UInt64`→`NUMERIC`, `USE`-in-Initial-SQL), default-database-for-Custom-SQL behavior, a `readonly=1` limitation note, and a Troubleshooting section.
  - **`tests/connection.test.js`** — new Node-based unit tests (16 assertions) covering both connection scripts and their edge cases.

  ## Notes / limitations

  - **`UInt64`/`Int128`/`(U)Int256` are now `NUMERIC`** instead of strings. The V2 driver ignores a JDBC-level type map in 0.9.x; a replacement (`jdbc_type_map`) is expected in a later driver release. Use `toString(col)` in Custom SQL/views if you need exact string representation.
  - **`readonly=1` accounts cannot connect** — the V2 driver sends server settings with every request; a `readonly=2` (or `0`) profile is required. This is a driver-level behavior, not something the connector can work around.
  - `CAP_JDBC_QUERY_CANCEL` is intentionally **not** enabled: the driver's cancel issues `KILL QUERY` over the same session and would hit `SESSION_IS_LOCKED` when the session id is in use.

  ## Verification

  - 16/16 Node tests pass; the official SDK packager (`tableau-2024.2`) validates the XML and builds the taco.
  - JDBC smoke test with the connector-generated URL/properties against ClickHouse 26.2 (driver 0.9.8): connect, `join_use_nulls` applied, session `SET` persistence across statements, `UInt64` max via `getBigDecimal`, `DatabaseMetaData` (`getSchemas`/`getTables`), `toTimeWithFixedDate`.
  - Tableau Desktop 2025.1: schema browsing, a simple viz, Initial SQL `SET`, a `MAKETIME` calculated field, and Custom SQL with unqualified tables resolving against the UI-selected database.
