### PR TITLE
Fix TLS: drop unsupported sslmode JDBC property (client-v2 rejects it)

### DIFF
--- a/clickhouse_jdbc/connectionProperties.js
+++ b/clickhouse_jdbc/connectionProperties.js
@@ -15,7 +15,6 @@
    
     if (attr["sslmode"] == "require") {
         props["ssl"] = "true";
-        props["sslmode"] = "STRICT";
     }
 
     return props;


### PR DESCRIPTION
### What

Drop the unsupported `sslmode` JDBC connection property from the ClickHouse connector; keep `ssl=true`.

```diff
     if (attr["sslmode"] == "require") {
         props["ssl"] = "true";
-        props["sslmode"] = "STRICT";
     }
```

### Why

The client-v2 `clickhouse-jdbc` driver (0.9.x) does not recognize a `sslmode` property and rejects it with:

```
ClientMisconfigurationException: Unknown and unmapped config properties: [sslmode]
```

So any TLS connection (e.g. ClickHouse Cloud, where the datasource sets `sslmode=require`) fails to connect. `ssl=true` on its own is the correct way to enable TLS with this driver — the extra `sslmode=STRICT` is both unnecessary and fatal.

### Validation

Confirmed via TDVT: with this fix the TLS `cloud` target reaches the same standard-suite baseline as the plaintext `latest`/`head` targets; without it the cloud connection fails outright. It unblocks the `cloud` cell of the Tableau TDVT workflow in `ClickHouse/connectors` (which checks out this repo's `main`).
